### PR TITLE
Redirect uri fix

### DIFF
--- a/src/Microsoft.Azure.Functions.Authentication.WebAssembly/EasyAuthRemoteAuthenticationService.cs
+++ b/src/Microsoft.Azure.Functions.Authentication.WebAssembly/EasyAuthRemoteAuthenticationService.cs
@@ -11,11 +11,11 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
-using Microsoft.Azure.Functions.Authentication.WebAssembly .Models;
+using Microsoft.Azure.Functions.Authentication.WebAssembly.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
-namespace Microsoft.Azure.Functions.Authentication.WebAssembly 
+namespace Microsoft.Azure.Functions.Authentication.WebAssembly
 {
     class EasyAuthRemoteAuthenticationService<TAuthenticationState> : AuthenticationStateProvider, IRemoteAuthenticationService<TAuthenticationState> where TAuthenticationState : RemoteAuthenticationState
     {

--- a/src/Microsoft.Azure.Functions.Authentication.WebAssembly/EasyAuthRemoteAuthenticationService.cs
+++ b/src/Microsoft.Azure.Functions.Authentication.WebAssembly/EasyAuthRemoteAuthenticationService.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Functions.Authentication.WebAssembly
 
             string stateId = Guid.NewGuid().ToString();
             await this.JSRuntime.InvokeVoidAsync($"{browserStorageType}.setItem", $"{storageKeyPrefix}.{stateId}", JsonSerializer.Serialize(context.State));
-            this.Navigation.NavigateTo($"/.auth/login/{easyAuthContext.SelectedProvider}?post_login_redirect_uri={this.Options.AuthenticationPaths.LogInCallbackPath}/{stateId}", forceLoad: true);
+            this.Navigation.NavigateTo($"/.auth/login/{easyAuthContext.SelectedProvider}?post_login_redirect_uri={this.BuildRedirectUri(this.Options.AuthenticationPaths.LogInCallbackPath)}/{stateId}", forceLoad: true);
 
             return new RemoteAuthenticationResult<TAuthenticationState> { Status = RemoteAuthenticationStatus.Redirect };
         }
@@ -112,9 +112,14 @@ namespace Microsoft.Azure.Functions.Authentication.WebAssembly
 
         public Task<RemoteAuthenticationResult<TAuthenticationState>> SignOutAsync(RemoteAuthenticationContext<TAuthenticationState> context)
         {
-            this.Navigation.NavigateTo($"/.auth/logout?post_logout_redirect_uri={this.Options.AuthenticationPaths.LogOutCallbackPath}", forceLoad: true);
+            this.Navigation.NavigateTo($"/.auth/logout?post_logout_redirect_uri={this.BuildRedirectUri(this.Options.AuthenticationPaths.LogOutCallbackPath)}", forceLoad: true);
 
             return Task.FromResult(new RemoteAuthenticationResult<TAuthenticationState> { Status = RemoteAuthenticationStatus.Redirect });
+        }
+
+        string BuildRedirectUri(string path)
+        {
+            return new Uri(new Uri(this.Navigation.BaseUri), path).ToString();
         }
     }
 }

--- a/src/Microsoft.Azure.Functions.Authentication.WebAssembly/Microsoft.Azure.Functions.Authentication.WebAssembly.csproj
+++ b/src/Microsoft.Azure.Functions.Authentication.WebAssembly/Microsoft.Azure.Functions.Authentication.WebAssembly.csproj
@@ -26,9 +26,9 @@
 
   <!-- NuGet package configuration -->
   <PropertyGroup>
-    <MajorVersion>0</MajorVersion>
-    <MinorVersion>2</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <MajorVersion>1</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>1</PatchVersion>
     <Version>$(MajorVersion).$(MinorVersion).$(PatchVersion)$(VersionSuffix)</Version>
     <Company>Microsoft Corporation</Company>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
The URI generated for the login/logout redirects weren't absolute paths as required by https://docs.microsoft.com/en-gb/azure/static-web-apps/authentication-authorization#post-login-redirect

Fixed to use an absolute path, and bumping the csproj version to match.